### PR TITLE
wip on 4 comments to closed issue #73

### DIFF
--- a/pages/confession-steps.js
+++ b/pages/confession-steps.js
@@ -70,15 +70,15 @@ export default function ConfessionSteps() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [page])
   return (
-    <div className="layout-appbar gap-7">
-      <h1 className="h1">{t('ConfessionFaith', { ns: 'common' })}:</h1>
-      <div className="flex flex-row h-full justify-center sm:w-4/5 max-w-7xl gap-4">
+    <div className="layout-appbar">
+      <h1 className="h1 text-center">{t('ConfessionFaith', { ns: 'common' })}:</h1>
+      <div className="flex flex-row h-full flex-wrap sm:flex-nowrap justify-evenly sm:justify-center w-full xl:w-4/5 max-w-7xl gap-4">
         <div className="flex items-center">
           <button disabled={page < 1} onClick={prevPage} className="arrow">
             <LeftArrow />
           </button>
         </div>
-        <div className="confession-text w-full min-h-[18rem]">{arrConfText[page]}</div>
+        <div className="confession-text">{arrConfText[page]}</div>
         <div className="flex items-center">
           <button disabled={page > 4} onClick={nextPage} className="arrow">
             <RightArrow />
@@ -87,7 +87,7 @@ export default function ConfessionSteps() {
       </div>
       <div
         className={`flex flex-row items-center space-x-6 ${
-          page === 5 ? '' : 'invisible'
+          page === 5 ? 'block' : 'hidden'
         }`}
       >
         <div className="space-x-1.5 items-center h4">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 .arrow{
-	@apply p-2 sm:px-6 sm:py-5 rounded-full duration-300
+	@apply px-6 py-5 rounded-full duration-300
 	hover:bg-white
 	active:bg-gray-100
 	disabled:opacity-30
@@ -38,14 +38,14 @@ disabled:bg-white disabled:hover:border-gray-300 disabled:hover:bg-white disable
 }
 
 .confession-text{
-	@apply h4 bg-white rounded-lg py-6 px-10 flex flex-col justify-center
+	@apply w-full min-h-[30rem] md:min-h-[23rem] lg:min-h-[18rem] h4 bg-white rounded-lg sm:mb-0 py-6 px-10 flex flex-col justify-center order-first sm:order-none 
 }
 
 .layout-empty{
 	@apply flex justify-center font-sans px-3 min-h-screen flex-col
 }
 .layout-appbar{
-	@apply flex flex-col justify-around sm:justify-center f-screen-appbar items-center font-sans px-5
+	@apply flex flex-col sm:justify-center f-screen-appbar items-center font-sans px-5 gap-7
 }
 
 .text-alignment{


### PR DESCRIPTION
> 1. в мобильном режиме я думаю лучше убрать justify-content: space-around; и пусть все блоки будут просто сверху вниз.
> 2. у confession-text убрать отступ чтобы стрелки были ближе

убрал выравнивание на мобильном режиме и отступ от текста к кнопкам

> 3. в таком случае попробовать сделать чтобы кнопки были не invisible а просто скрыты. А то invisible резервирует же место под них

заменил. Установил для тех страниц где скрыть - hidden, а где надо отображать - block


> 4. У нас текст будет на разных языках разный по размеру. То что ты прописал для каждого экрана примерный размер блока, чтобы весь контент помещался - это возможно не везде будет работать, надо это учесть

этот пункт оставил пока как есть. 
В настройках для класса confession-text я и указал, что это min-h-[30rem] md:min-h-[23rem] lg:min-h-[18rem]. 
В противном случае, размеры  текстового окна будут прыгать, если установить на fit content или же вернуть одно общее значение на высоту min-h-[18rem]. 
Помоему можно так сперва оставить, чтобы ребята посмотрели и дали свой фидбек.