### PR TITLE
Changing Project code does not work when editing project settings

### DIFF
--- a/components/BasicInformation.js
+++ b/components/BasicInformation.js
@@ -14,7 +14,6 @@ function BasicInformation({
   project,
   methods,
   setIsOpenLanguageCreate,
-  isProjectEdit = false,
   uniqueCheck = false,
 }) {
   const { t } = useTranslation(['projects', 'project-edit', 'common'])
@@ -83,7 +82,6 @@ function BasicInformation({
           : errors?.code?.type === 'notUniqueProject'
           ? t('CodeMessageErrorNotUniqueProject')
           : '',
-      readOnly: isProjectEdit,
     },
   ]
 

--- a/components/ProjectEdit/ProjectEdit.js
+++ b/components/ProjectEdit/ProjectEdit.js
@@ -175,7 +175,6 @@ function ProjectEdit() {
                   setIsOpenLanguageCreate={setIsOpenLanguageCreate}
                   uniqueCheck={getValues('code') !== code}
                   project={project}
-                  isProjectEdit={true}
                 />
                 <ButtonLoading isLoading={isSavingBasic}>{t('Save')}</ButtonLoading>
               </form>
@@ -354,7 +353,6 @@ function ProjectEdit() {
                 uniqueCheck={getValuesSmall('code') !== code}
                 setValue={setValueSmall}
                 project={project}
-                isProjectEdit={true}
               />
               <input className="btn-primary" type="submit" value={t('Save')} />
             </form>

--- a/pages/api/projects/[code]/index.js
+++ b/pages/api/projects/[code]/index.js
@@ -41,10 +41,11 @@ export default async function projectHandler(req, res) {
           project_code: code,
         })
         if (error) throw error
+
+        return res.status(200).json({ success: 'updated' })
       } catch (error) {
         return res.status(404).json({ error })
       }
-      return res.status(200).json({ success: 'updated' })
 
     default:
       res.setHeader('Allow', ['GET', 'PUT'])

--- a/supabase/migrations/20240401125058_fix_update_project_basic.sql
+++ b/supabase/migrations/20240401125058_fix_update_project_basic.sql
@@ -1,0 +1,33 @@
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.update_project_basic(project_code text, title text, orig_title text, code text, language_id bigint)
+ RETURNS boolean
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$DECLARE
+  project_id BIGINT;
+BEGIN
+  SELECT id FROM public.projects WHERE projects.code = project_code INTO project_id;
+  IF authorize(auth.uid(), project_id) NOT IN ('admin') THEN
+    RAISE EXCEPTION SQLSTATE '42000' USING MESSAGE = 'No access rights to this function';
+  END IF;
+  
+  IF update_project_basic.project_code != update_project_basic.code THEN
+    SELECT id FROM public.projects WHERE projects.code = update_project_basic.code INTO project_id;
+    IF project_id IS NOT NULL THEN
+      RAISE EXCEPTION SQLSTATE '23505' USING MESSAGE = 'This project code is already in use';
+    END IF;
+      
+    SELECT id FROM public.projects WHERE projects.code = update_project_basic.project_code INTO project_id;
+    IF project_id IS NOT NULL THEN
+      UPDATE PUBLIC.projects SET code = update_project_basic.code, title = update_project_basic.title, orig_title = update_project_basic.orig_title, language_id = update_project_basic.language_id WHERE projects.id = project_id;
+      RETURN TRUE;
+    END IF;
+  END IF;
+
+  UPDATE PUBLIC.projects SET code = update_project_basic.code, title=update_project_basic.title, orig_title = update_project_basic.orig_title, language_id = update_project_basic.language_id WHERE projects.id = project_id;
+  RETURN TRUE;
+END;$function$
+;
+
+

--- a/supabase/migrations/20240401163532_fix_update_project_basic.sql
+++ b/supabase/migrations/20240401163532_fix_update_project_basic.sql
@@ -4,7 +4,7 @@ CREATE OR REPLACE FUNCTION public.update_project_basic(project_code text, title 
  RETURNS boolean
  LANGUAGE plpgsql
  SECURITY DEFINER
-AS $function$DECLARE
+AS $function$ DECLARE
   project_id BIGINT;
 BEGIN
   SELECT id FROM public.projects WHERE projects.code = project_code INTO project_id;
@@ -19,15 +19,12 @@ BEGIN
     END IF;
       
     SELECT id FROM public.projects WHERE projects.code = update_project_basic.project_code INTO project_id;
-    IF project_id IS NOT NULL THEN
-      UPDATE PUBLIC.projects SET code = update_project_basic.code, title = update_project_basic.title, orig_title = update_project_basic.orig_title, language_id = update_project_basic.language_id WHERE projects.id = project_id;
-      RETURN TRUE;
-    END IF;
   END IF;
 
   UPDATE PUBLIC.projects SET code = update_project_basic.code, title=update_project_basic.title, orig_title = update_project_basic.orig_title, language_id = update_project_basic.language_id WHERE projects.id = project_id;
   RETURN TRUE;
-END;$function$
+END;
+$function$
 ;
 
 


### PR DESCRIPTION
The temporary readOnly mode for editing project code has been removed from the BasicInformation component. A bug in the RPC function was fixed, after which changing the project code does not break the application and successfully makes changes to the project code

***
Из компонента BasicInformation был удалён временный режим readOnly редактирования кода проекта. Была исправлена ошибка в RPC функции после чего изменение кода проекта не ломает приложение и успешно вносит изменения в код проекта