### PR TITLE
Displaying a list of translators

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -39,6 +39,7 @@ export default function Footer({
     setIsStepPage(router.pathname === '/translate/[project]/[book]/[chapter]/[step]')
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router.pathname])
+
   return (
     <div className="relative flex flex-col justify-between items-center py-4 md:py-0 mx-auto md:w-full max-w-7xl bg-th-secondary-100 md:flex-row lg:px-4 xl:px-0">
       {isStepPage && (

--- a/components/ProjectCard.js
+++ b/components/ProjectCard.js
@@ -47,7 +47,10 @@ function ProjectCard({ project, user }) {
                   <p>{t('Language')}:</p>
                   <p className="text-th-secondary-300">{project.languages.orig_name}</p>
                 </div>
-                <div className="flex gap-3">
+                <div
+                  className="flex gap-3 cursor-default"
+                  onClick={(e) => e.stopPropagation()}
+                >
                   <p>{t('common:Translator_other')}:</p>
                   <Translators
                     projectCode={project.code}

--- a/components/TranslatorImage.js
+++ b/components/TranslatorImage.js
@@ -1,6 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
-
-import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
 
 import { useRecoilValue } from 'recoil'
 import { userAvatarState } from './state/atoms'
@@ -17,24 +15,9 @@ const defaultColor = [
   'fill-th-divide-verse9',
 ]
 
-function TranslatorImage({
-  item,
-  size,
-  clickable,
-  showModerator = false,
-  isPointerCursor = false,
-}) {
+function TranslatorImage({ item, size, showModerator = false, isPointerCursor = false }) {
   const [userAvatarUrl, setUserAvatarUrl] = useState(item?.users?.avatar_url || null)
   const userAvatar = useRecoilValue(userAvatarState)
-  const {
-    push,
-    query: { project, book, chapter, step, translator },
-  } = useRouter()
-
-  const canClick = useMemo(
-    () => clickable && (!translator || translator !== item.users?.login),
-    [clickable, item.users?.login, translator]
-  )
 
   useEffect(() => {
     userAvatar?.id === item.users?.id
@@ -42,16 +25,11 @@ function TranslatorImage({
       : setUserAvatarUrl(item?.users?.avatar_url || null)
   }, [item.users?.id, item.users?.avatar_url, userAvatar])
 
-  const cursorStyle = isPointerCursor || canClick ? 'cursor-pointer' : 'cursor-default'
+  const cursorStyle = isPointerCursor ? 'cursor-pointer' : ''
 
   return (
     <div
       title={`${item?.users ? `${item.users?.login}` : ''}`}
-      onClick={() => {
-        if (canClick) {
-          push(`/translate/${project}/${book}/${chapter}/${step}/${item?.users?.login}`)
-        }
-      }}
       className={`relative ${cursorStyle} ${
         showModerator && item.is_moderator ? 'border-th-secondary-400 border-2' : ''
       } rounded-full select-none`}

--- a/components/Translators.js
+++ b/components/Translators.js
@@ -1,5 +1,7 @@
 import TranslatorImage from 'components/TranslatorImage'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
+
+import Modal from './Modal'
 
 import { useTranslators } from 'utils/hooks'
 
@@ -12,6 +14,7 @@ function Translators({
   isStep = false,
   activeTranslators = [],
 }) {
+  const [isModalOpen, setIsModalOpen] = useState(false)
   const [projectTranslators] = useTranslators({
     code: projectCode,
   })
@@ -24,29 +27,72 @@ function Translators({
     )
   }, [activeTranslators, isStep, projectTranslators])
 
+  const visibleTranslators = translators.slice(0, 4)
+  const hiddenCount = Math.max(translators.length - 4, 0)
+
   return (
-    <div
-      className={`flex items-center z-10 overflow-x-auto ${
-        isStep ? 'max-w-xs p-2' : 'max-w-full flex-wrap'
-      }`}
-    >
-      {translators && translators.length > 0 && (
-        <>
-          {translators.map((item, key) => {
-            return (
-              <div key={key} className={className}>
-                <TranslatorImage
-                  clickable={clickable}
-                  item={item}
-                  size={size}
-                  showModerator={showModerator}
-                />
+    <>
+      <div
+        className={`flex items-center z-10 ${
+          isStep ? 'max-w-xs p-2 overflow-x-auto' : 'max-w-full flex-wrap'
+        }`}
+      >
+        {visibleTranslators.map((item, key) => (
+          <div key={key} className={className}>
+            <TranslatorImage
+              clickable={clickable}
+              item={item}
+              size={size}
+              showModerator={showModerator}
+            />
+          </div>
+        ))}
+        {hiddenCount > 0 && (
+          <div
+            className={`${className} flex items-center justify-center bg-th-primary-500 text-th-text-secondary-100 rounded-full text-xs z-10 cursor-pointer`}
+            style={{ width: size, height: size }}
+            onClick={() => setIsModalOpen(true)}
+          >
+            +{hiddenCount}
+          </div>
+        )}
+      </div>
+
+      <Modal
+        isOpen={isModalOpen}
+        closeHandle={() => setIsModalOpen(false)}
+        title="All Translators"
+        className={{
+          dialogTitle: 'text-2xl font-medium leading-6',
+          dialogPanel:
+            'w-full max-w-md px-7 py-10 align-middle transform overflow-y-auto shadow-xl transition-all bg-th-primary-100 text-th-text-secondary-100 rounded-3xl',
+        }}
+      >
+        <div className="flex flex-wrap gap-1.5 my-6 py-3 max-h-[50vh] overflow-y-auto">
+          {translators.map((participant, index) => (
+            <div key={index} className="flex items-center pb-1">
+              <div className="flex flex-1 items-center gap-2.5 pl-1 pr-3 py-1 border rounded-3xl w-5/6 text-th-text-secondary-100">
+                <div className="w-8 h-8 min-w-[2rem]">
+                  <TranslatorImage
+                    item={participant}
+                    clickable={clickable}
+                    showModerator={showModerator}
+                  />
+                </div>
+                <div>
+                  <p className="text-lg">{participant.users.login}</p>
+                </div>
               </div>
-            )
-          })}
-        </>
-      )}
-    </div>
+            </div>
+          ))}
+        </div>
+        <div className="text-center">
+          <button className="btn-secondary" onClick={() => setIsModalOpen(false)}>
+            Close
+          </button>
+        </div>
+      </Modal>
+    </>
   )
 }
 

--- a/components/Translators.js
+++ b/components/Translators.js
@@ -1,19 +1,22 @@
-import TranslatorImage from 'components/TranslatorImage'
 import { useMemo, useState } from 'react'
 
+import { useTranslation } from 'next-i18next'
+
 import Modal from './Modal'
+import TranslatorImage from 'components/TranslatorImage'
 
 import { useTranslators } from 'utils/hooks'
 
 function Translators({
   projectCode,
   size,
-  clickable = false,
   className,
   showModerator,
   isStep = false,
+  clickable = false,
   activeTranslators = [],
 }) {
+  const { t } = useTranslation('common')
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [projectTranslators] = useTranslators({
     code: projectCode,
@@ -61,34 +64,37 @@ function Translators({
       <Modal
         isOpen={isModalOpen}
         closeHandle={() => setIsModalOpen(false)}
-        title="All Translators"
+        title={t('AllTranslators')}
         className={{
           dialogTitle: 'text-2xl font-medium leading-6',
           dialogPanel:
             'w-full max-w-md px-7 py-10 align-middle transform overflow-y-auto shadow-xl transition-all bg-th-primary-100 text-th-text-secondary-100 rounded-3xl',
         }}
       >
-        <div className="flex flex-wrap gap-1.5 my-6 py-3 max-h-[50vh] overflow-y-auto">
+        <div className="flex flex-wrap gap-x-1.5 gap-y-2.5 my-6 py-3 max-h-[50vh] overflow-y-auto">
           {translators.map((participant, index) => (
-            <div key={index} className="flex items-center pb-1">
-              <div className="flex flex-1 items-center gap-2.5 pl-1 pr-3 py-1 border rounded-3xl w-5/6 text-th-text-secondary-100">
-                <div className="w-8 h-8 min-w-[2rem]">
-                  <TranslatorImage
-                    item={participant}
-                    clickable={clickable}
-                    showModerator={showModerator}
-                  />
-                </div>
-                <div>
-                  <p className="text-lg">{participant.users.login}</p>
-                </div>
+            <div
+              key={index}
+              className="group flex items-center gap-2.5 pl-1 pr-3 py-1 border rounded-3xl"
+            >
+              <div
+                className={`w-8 h-8 ${
+                  clickable ? 'transition-opacity	duration-300 group-hover:opacity-50' : ''
+                }`}
+              >
+                <TranslatorImage
+                  item={participant}
+                  clickable={clickable}
+                  showModerator={showModerator}
+                />
               </div>
+              <p className="text-lg cursor-default">{participant.users.login}</p>
             </div>
           ))}
         </div>
         <div className="text-center">
           <button className="btn-secondary" onClick={() => setIsModalOpen(false)}>
-            Close
+            {t('Close')}
           </button>
         </div>
       </Modal>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -4,6 +4,7 @@
   "Added": "Add",
   "AddWord": "Add word",
   "AllNotes": "All notes",
+  "AllTranslators": "All Translators",
   "aquifer": "Aquifer",
   "AreYouSureDelete": "Are you sure you want to delete",
   "AreYouSureGoToNextStep": "Are you sure you want to go to next step?",

--- a/supabase/migrations/20240622142654_add_function_get_active_translators.sql
+++ b/supabase/migrations/20240622142654_add_function_get_active_translators.sql
@@ -8,7 +8,7 @@ CREATE FUNCTION PUBLIC.get_active_translators(project_code TEXT, book_code PUBLI
 LANGUAGE plpgsql SECURITY DEFINER AS $$
 BEGIN
     -- must be on the project
-    IF authorize(auth.uid(), (SELECT id FROM projects WHERE code = get_active_translators.project_code)) NOT IN ('user', 'admin', 'coordinator', 'moderator') THEN
+    IF authorize(auth.uid(), (SELECT id FROM projects WHERE code = get_active_translators.project_code)) NOT IN ('user', 'admin', 'coordinator', 'moderator', 'translator') THEN
         RETURN;
     END IF;
 


### PR DESCRIPTION
In the Translators component, the display of users has been updated and a modal window has been added to view the full list of translators.
If there are more than four translators working on a chapter, an additional icon appears with the number of translators that are not displayed. In a modal window, if the TranslatorImage is clickable, then when hovering over the user, a hover is triggered, which adds transparency to the TranslatorImage, thereby indicating that the TranslatorImage is clickable.

***

в компоненте Translators обновлено отображение пользователей, добавлено модальное окно для просмотра полного списка переводчиков.
Если над главой работает больше четырёх переводчиков, появляется дополнительная иконка с числом переводчиков, которые не отображаются. В модальном окне, если TranslatorImage кликабельна, то при наведении на пользователя срабатывает ховер, который добавляет прозрачность для TranslatorImage, тем самым подсказывая, что TranslatorImage кликабельный.