### PR TITLE
When clicked on transaltors in list - open Modal with translators

### DIFF
--- a/components/Translators.js
+++ b/components/Translators.js
@@ -60,16 +60,12 @@ function Translators({
         }`}
       >
         {visibleTranslators.map((translator, key) => (
-          <div
-            key={key}
-            className={className}
-            onClick={() => handleTranslatorClick(translator)}
-          >
+          <div key={key} className={className} onClick={() => setIsModalOpen(true)}>
             <TranslatorImage
               item={translator}
               size={size}
               showModerator={showModerator}
-              isPointerCursor={clickable}
+              isPointerCursor
             />
           </div>
         ))}


### PR DESCRIPTION
Now the winder with the list of translators always opens when you click on any of them in the Translators component.
Теперь модалка со списком прееводчиков открывается всегда при клике на любого из них в компоненте Translators.